### PR TITLE
Bug fix for resizing FB.ui

### DIFF
--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -188,7 +188,7 @@ FB.provide('UIServer', {
     var call = {
       cb     : cb,
       id     : id,
-      size   : method.size || {},
+      size   : params.size || method.size || {},
       url    : FB._domain.www + method.url,
       params : params
     };


### PR DESCRIPTION
## Description

This problem has been expressed here and here:
- http://stackoverflow.com/questions/2948517/fb-ui-and-setting-popup-size
- http://stackoverflow.com/questions/2713379/showing-popup-in-the-new-fb-js-sdk

The problematic function is prepareCall: function(params, cb) inside ui.js

The size param that user set, for example: size: {width: 500, height: 671}, was not passed onto the call object.
## Solution

before fix:
    var call = {
      cb : cb,
      id : id,
      size : method.size || {},
      url : FB._domain.www + method.url,
      params : params
    };

after fix:
    var call = {
      cb     : cb,
      id     : id,
      size   : params.size || method.size || {},
      url    : FB._domain.www + method.url,
      params : params
    };
