### PR TITLE
FB.QS.decode amp and equal bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /jscoverage-report/
 /m.js
 /nginx.conf
+*.swp

--- a/src/core/qs.js
+++ b/src/core/qs.js
@@ -61,14 +61,14 @@ FB.provide('QS', {
     var
       decode = decodeURIComponent,
       params = {},
-      parts  = str.split('&'),
+      parts  = str.split(/&(?!amp;)/gi),
       i,
       pair;
 
     for (i=0; i<parts.length; i++) {
-      pair = parts[i].split('=', 2);
+      pair = parts[i].split('=');
       if (pair && pair[0]) {
-        params[decode(pair[0])] = decode(pair[1]);
+        params[decode(pair.shift())] = decode(pair.join('='));
       }
     }
 

--- a/tests/js/qs.js
+++ b/tests/js/qs.js
@@ -92,3 +92,27 @@ test(
     ok(!('' in empty), 'should not find empty value');
   }
 );
+
+test(
+  'query string ampersand html entity bug',
+
+  function() {
+    var params = FB.QS.decode('a=1&b=loren&amp;hardy&c=3');
+
+    ok(params.a == 1, 'expect a==1 in params');
+    ok(params.b == 'loren&amp;hardy', 'expect b=="loren&amp;hardy" in params');
+    ok(params.c == 3, 'expect c==3 in params');
+  }
+);
+
+test(
+  'query string multiple equal sign bug',
+
+  function() {
+    var params = FB.QS.decode('a=1&b==2&c===3==4');
+
+    ok(params.a == 1, 'expect a==1 in params');
+    ok(params.b == '=2', 'expect b=="=2" in params');
+    ok(params.c == '==3==4', 'expect c=="==3==4" in params'); 
+  }
+);


### PR DESCRIPTION
I had written some test case before I have changed FB.QS.decode function.

QS rules of test failed when I ran test.

I have fixed ampersand html entity bug and multiple equal sign.
