### PR TITLE
made _domain.staticfb SSL aware

### DIFF
--- a/src/core/prelude.js
+++ b/src/core/prelude.js
@@ -84,7 +84,9 @@ if (!window.FB) {
                    ? 'https://s-static.ak.fbcdn.net/'
                    : 'http://static.ak.fbcdn.net/'),
       graph    : 'https://graph.facebook.com/',
-      staticfb : 'http://static.ak.facebook.com/',
+      staticfb : (window.location.protocol == 'https:'
+                   ? 'https://s-static.ak.facebook.com/'
+                   : 'http://static.ak.facebook.com/'),
       www      : window.location.protocol + '//www.facebook.com/'
     },
     _locale: null,


### PR DESCRIPTION
made _domain.staticfb SSL aware. this resource not being SSL aware is causing iframes to not resize properly in IE[6789] when loading facebook via SSL/HTTPS.

this is causing a lot of my clients to question why they're seeing scroll bars on their tabs, and on the canvas; telling them "it's just broken" isn't really a good excuse any more.
