### PR TITLE
removal of document.documentElement hiding

### DIFF
--- a/src/core/xd.js
+++ b/src/core/xd.js
@@ -271,9 +271,6 @@ FB.provide('XD', {
         // loaded before or after
         FB.init = FB.getLoginStatus = FB.api = function() {};
 
-        // display none helps prevent loading of some stuff
-        document.documentElement.style.display = 'none';
-
         FB.XD.resolveRelation(
           FB.QS.decode(fragment).relation).FB.XD.recv(fragment);
       }


### PR DESCRIPTION
`// display none helps prevent loading of some stuff`

It completely hides and kills any page in IE 6 that doesn't have Flash Installed because the script fallback to some absurt transport method for cross domain communication in IE 6.. So let's not kill pages by default for the sake of performance gain..

But his issue doesn't only affect IE6, because we have nice self executing here that is executed in every, single browser:

https://github.com/facebook/connect-js/blob/master/src/core/xd.js#L284-289

So simply appending `fb_xd_fragment` to a site's url that uses the connect-js library will hide the complete page.

Fun stuff!
